### PR TITLE
feat: Add EMI support for Summoning Table recipes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,10 @@ group = mod_group_id
 
 repositories {
     mavenLocal()
+    maven {
+        name = "TerraformersMC"
+        url = "https://maven.terraformersmc.com/"
+    }
 }
 
 base {
@@ -88,6 +92,8 @@ dependencies {
 
     runtimeOnly "maven.modrinth:worldedit:7.3.6"
 
+    compileOnly "dev.emi:emi-neoforge:${emi_version}:api"
+    runtimeOnly "dev.emi:emi-neoforge:${emi_version}"
 }
 
 var generateModMetadata = tasks.register("generateModMetadata", ProcessResources) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,7 @@ jer_version=1.5.1.10
 curios_version=9.0.9+1.21
 gekolib_version=1.21.1:4.6.6
 patchouli_version=87
+emi_version=1.1.18+1.21.1
 
 mod_id=jitl
 mod_name=Journey Into the Light

--- a/src/main/java/net/jitl/core/helper/EnumSummoningRecipes.java
+++ b/src/main/java/net/jitl/core/helper/EnumSummoningRecipes.java
@@ -3,6 +3,8 @@ package net.jitl.core.helper;
 import net.jitl.core.init.internal.JItems;
 import net.minecraft.world.item.Item;
 
+import java.util.Arrays;
+
 public enum EnumSummoningRecipes {
     OKOLOO(new Item[]{
             JItems.BLOODCRUST_INGOT.get(),
@@ -158,7 +160,15 @@ public enum EnumSummoningRecipes {
         return items[index];
     }
 
+    public Item[] getInputs() {
+        return Arrays.copyOfRange(items, 0, items.length - 1);
+    }
+
+    public Item getOutput() {
+        return items[items.length - 1];
+    }
+
     public String getName() {
-        return getItem(7).asItem().toString();
+        return getOutput().asItem().toString();
     }
 }

--- a/src/main/java/net/jitl/core/init/compat/emi/JITLEmiPlugin.java
+++ b/src/main/java/net/jitl/core/init/compat/emi/JITLEmiPlugin.java
@@ -1,0 +1,31 @@
+package net.jitl.core.init.compat.emi;
+
+
+import dev.emi.emi.api.EmiEntrypoint;
+import dev.emi.emi.api.EmiInitRegistry;
+import dev.emi.emi.api.EmiPlugin;
+import dev.emi.emi.api.EmiRegistry;
+import dev.emi.emi.api.stack.EmiStack;
+import net.jitl.core.helper.EnumSummoningRecipes;
+import net.jitl.core.init.compat.emi.category.SummoningTableEmiCategory;
+import net.jitl.core.init.compat.emi.recipe.SummoningTableEmiRecipe;
+import net.jitl.core.init.internal.JBlocks;
+
+@EmiEntrypoint
+public class JITLEmiPlugin implements EmiPlugin {
+    public static final SummoningTableEmiCategory SUMMONING_TABLE = new SummoningTableEmiCategory();
+
+    @Override
+    public void initialize(EmiInitRegistry registry) {
+        EmiPlugin.super.initialize(registry);
+    }
+
+    @Override
+    public void register(EmiRegistry registry) {
+        registry.addCategory(SUMMONING_TABLE);
+        registry.addWorkstation(SUMMONING_TABLE, EmiStack.of(JBlocks.SUMMONING_TABLE));
+        for (EnumSummoningRecipes recipe : EnumSummoningRecipes.values()) {
+            registry.addRecipe(new SummoningTableEmiRecipe(recipe));
+        }
+    }
+}

--- a/src/main/java/net/jitl/core/init/compat/emi/category/SummoningTableEmiCategory.java
+++ b/src/main/java/net/jitl/core/init/compat/emi/category/SummoningTableEmiCategory.java
@@ -1,0 +1,17 @@
+package net.jitl.core.init.compat.emi.category;
+
+import dev.emi.emi.api.recipe.EmiRecipeCategory;
+import dev.emi.emi.api.stack.EmiStack;
+import net.jitl.core.init.internal.JBlocks;
+import net.minecraft.resources.ResourceLocation;
+
+public class SummoningTableEmiCategory extends EmiRecipeCategory {
+    public static ResourceLocation ID = ResourceLocation.fromNamespaceAndPath("jitl", "summoning_table");
+
+    public SummoningTableEmiCategory() {
+        // First argument is the ID of the category across the EMI
+        // Second argument refers to the item to use as the icon for the category
+        // Third(optional) argument is the item to use as the icon for the category in the recipe tree
+        super(ID, EmiStack.of(JBlocks.SUMMONING_TABLE));
+    }
+}

--- a/src/main/java/net/jitl/core/init/compat/emi/recipe/SummoningTableEmiRecipe.java
+++ b/src/main/java/net/jitl/core/init/compat/emi/recipe/SummoningTableEmiRecipe.java
@@ -1,0 +1,95 @@
+package net.jitl.core.init.compat.emi.recipe;
+
+import dev.emi.emi.api.recipe.EmiRecipe;
+import dev.emi.emi.api.recipe.EmiRecipeCategory;
+import dev.emi.emi.api.render.EmiTexture;
+import dev.emi.emi.api.stack.EmiIngredient;
+import dev.emi.emi.api.stack.EmiStack;
+import dev.emi.emi.api.widget.SlotWidget;
+import dev.emi.emi.api.widget.WidgetHolder;
+import net.jitl.core.helper.EnumSummoningRecipes;
+import net.jitl.core.init.compat.emi.JITLEmiPlugin;
+import net.minecraft.resources.ResourceLocation;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class SummoningTableEmiRecipe implements EmiRecipe {
+    private static final ResourceLocation RECIPE_BACKGROUND = ResourceLocation.fromNamespaceAndPath("jitl", "textures/gui/summoning_table_recipe.png");
+    private final ResourceLocation id;
+    private final List<EmiIngredient> inputs;
+    private final List<EmiStack> outputs;
+
+    public SummoningTableEmiRecipe(EnumSummoningRecipes recipe) {
+        this.id = ResourceLocation.fromNamespaceAndPath("jitl", "/summoning_table/" + recipe.name().toLowerCase());
+
+        this.inputs = Arrays.stream(recipe.getInputs())
+                .map(EmiStack::of)
+                .collect(Collectors.toList());
+
+        this.outputs = List.of(EmiStack.of(recipe.getOutput()));
+    }
+
+    @Override
+    public EmiRecipeCategory getCategory() {
+        return JITLEmiPlugin.SUMMONING_TABLE;
+    }
+
+    @Override
+    public @Nullable ResourceLocation getId() {
+        return id;
+    }
+
+    @Override
+    public List<EmiIngredient> getInputs() {
+        return inputs;
+    }
+
+    @Override
+    public List<EmiStack> getOutputs() {
+        return outputs;
+    }
+
+    @Override
+    public int getDisplayWidth() {
+        // This refers to 112 pixels from the Summoning Table recipe pattern - 8 pixels of the default pattern from EMI
+        return 104;
+    }
+
+    @Override
+    public int getDisplayHeight() {
+        // This refers to 62 pixels from the Summoning Table recipe pattern - 8 pixels of the default pattern from EMI
+        return 54;
+    }
+
+    @Override
+    public void addWidgets(WidgetHolder widgets) {
+        // Starting in -4 to correctly place the Summoning Table background on top of EMI's one
+        int xStart = -4;
+        int yStart = -4;
+
+        widgets.addTexture(new EmiTexture(RECIPE_BACKGROUND, 0, 0, 112, 62), xStart, yStart);
+
+        int[][] slotPositions = {
+                {xStart + 4, yStart + 4},    // Top-left
+                {xStart + 4, yStart + 22},   // Center-left
+                {xStart + 40, yStart + 4},   // Top-right
+                {xStart + 22, yStart + 22},  // Center
+                {xStart + 4, yStart + 40},   // Bottom-left
+                {xStart + 40, yStart + 22},  // Center-right
+                {xStart + 40, yStart + 40},  // Bottom-right
+        };
+        for (int i = 0; i < inputs.size(); i++) {
+            // Create a new slot widget for each input and don't draw the default grey background of the slot
+            SlotWidget slot = new SlotWidget(inputs.get(i), slotPositions[i][0], slotPositions[i][1]);
+            slot.drawBack(false);
+            widgets.add(slot);
+        }
+
+        SlotWidget outputSlot = new SlotWidget(outputs.getFirst(), xStart + 86, yStart + 22);
+        outputSlot.drawBack(false);
+        widgets.add(outputSlot).recipeContext(this);
+    }
+}


### PR DESCRIPTION
This adds EMI support for Summoning Table recipes.

At the time of this PR EMI did not received a update to 1.21.3, that's way I kept it within the 1.21.1 commit. Either way this code shouldn't conflit with the 1.21.3 work you've been doing and as soon as EMI updates to 1.21.3 you can [grab a version](https://github.com/emilyploszaj/emi/releases)  and update `gradle.properties`.